### PR TITLE
Change the logic for fetching the pull request details of a workflow run

### DIFF
--- a/data_fetching/__main__.py
+++ b/data_fetching/__main__.py
@@ -1,111 +1,104 @@
+import os
+from typing import Any
+
+import pandas as pd
+from hashlib import md5
 from cache import save_data_to_csv, PATH
+from cache import PATH as CACHE_PATH
+
 from utils import (
     fetch_workflows,
     fetch_workflow_runs,
     fetch_commit_details,
     fetch_pull_request_details,
-    fetch_pull_request_conversation,
-    fetch_issue_details
+    fetch_pull_request_comments,
+    fetch_issue_details,
+    get_pull_number
 )
 
-
-def get_push_events(commit_id, wf_name, wf_run):
-    commit_message, commit_author, commit_date, files_changed, lines_added, lines_deleted = fetch_commit_details(
-        commit_id)
-
-    commit_details = {
-        "workflow_name": wf_name,
-        "run_id": wf_run["id"],
-        "run_status": wf_run["status"],
-        "run_conclusion": wf_run["conclusion"],
-        "event": wf_run["event"],
-        "commit_id": commit_sha,
-        "commit_message": commit_message,
-        "commit_author": commit_author,
-        "commit_date": commit_date,
-        "lines_added": lines_added,
-        "lines_deleted": lines_deleted,
-        "files_changed": files_changed,
-    }
-    return commit_details
-
-
-def get_pull_request_events(pull_request_id, wf_name, wf_run):
-    pr_title, pr_author, pr_date, pr_body, pr_url, pr_labels = fetch_pull_request_details(pull_request_id)
-    pull_request_conversation = fetch_pull_request_conversation(pr_url) if pr_url else []
-    pull_request_details = {
-        "workflow_name": wf_name,
-        "run_id": wf_run["id"],
-        "run_status": wf_run["status"],
-        "run_conclusion": wf_run["conclusion"],
-        "event": wf_run["event"],
-        "pull_request_id": pull_request_id,
-        "pull_request_title": pr_title,
-        "pull_request_author": pr_author,
-        "pull_request_created_at": pr_date,
-        "Pull_request_label": pr_labels,
-        "pull_request_body": pr_body,
-        "pull_request_conversation": pull_request_conversation
-    }
-    return pull_request_details
-
-
-def get_issue_events(issue_id, wf_name, wf_run):
-    issue_id, issue_title, issue_author, issue_body, issue_url, issue_labels = fetch_issue_details(issue_id)
-    issue_details = {
-        "workflow_name": wf_name,
-        "run_id": wf_run["id"],
-        "run_status": wf_run["status"],
-        "run_conclusion": wf_run["conclusion"],
-        "event": wf_run["event"],
-        "issue_id": issue_number,
-        "issue_title": issue_title,
-        "issue_author": issue_author,
-        "issue_body": issue_body,
-        "issue_url": issue_url,
-        "issue_labels": issue_labels,
-    }
-    return issue_details
-
+file_name = PATH / "workflow_runs.csv"
 
 if __name__ == "__main__":
     workflows = fetch_workflows()
-    for workflow in workflows:
+    for workflow_index, workflow in enumerate(workflows):
+        print("Starting workflow {} of {}".format(workflow_index + 1, len(workflows)))
+        workflow_runs_list = []
         workflow_id = workflow["id"]
         workflow_name = workflow["name"]
+        # get all the runs for this particular workflow_id
+        print("Fetching workflow runs")
         runs = fetch_workflow_runs(workflow_id)
-        workflow_data_list = []
-
-        for run in runs:
+        print("Fetching completed")
+        for run_index, run in enumerate(runs):
+            print("Starting run {} of {}".format(run_index + 1, len(runs)))
+            run_details = []
             event = run["event"]
-            if event == "push":
-                commit_sha = run["head_sha"]
-                commit_data = get_push_events(commit_sha, workflow_name, run)
-                workflow_data_list.append(commit_data)
-
-            elif event == "pull_request":
-                pull_requests = run.get("pull_requests", [])
-                for pr_data in pull_requests:
-                    pr_number = pr_data["number"]
-                    pull_data_list = get_pull_request_events(pr_number, workflow_name, run)
-                    workflow_data_list.append(pull_data_list)
-
-            elif event == "issues":
-                issue_number = run["payload"]["issue"]["number"]
-                issue_data = get_issue_events(issue_number, workflow_name, run)
-                workflow_data_list.append(issue_data)
-
-            else:
-                print(f"Unsupported event: {event}")
+            run_id = run["id"]
+            commit_sha = run["head_sha"]
+            run_filename = md5((str(workflow_id) + str(run_id)).encode()).hexdigest() + '.csv'
+            # if the file is already present in the cache add its content to the list and skip
+            if os.path.exists(CACHE_PATH / run_filename):
+                file_content = pd.read_csv(CACHE_PATH / run_filename)
+                run_events_details = file_content.to_dict('records')
+                workflow_runs_list.append(run_events_details)
+                run_details.append(run_events_details)
                 continue
-            # Generate a unique file name using event type and timestamp or UUID
-            run_id = run["run_number"]
-            file_name = f"{workflow_name}_{event}_{run_id}.csv"
-            file_path = PATH / file_name
+            # fetch commit details
+            commit_message, commit_author, commit_date, files_changed, lines_added, lines_deleted = (
+                fetch_commit_details(commit_sha))
 
-            # If the file already exists, skip processing
-            if file_path.exists():
-                print(f"Skipping {file_name} as it has already been processed.")
-                continue
-            save_data_to_csv(workflow_data_list, file_name)
-            print(f"Data saved to {file_name}")
+            # Apply the logic to get all the pull requests for this commits by getting the pulls url or commit sha? sol: using sha
+            # How different is run["pulls_url"] vs pr that I get for each commit?
+            # I think the pr I fetch for each commit_sha of a run basically fetches pr for that commit which has to do nothing with runs! :) Since Fetching PR using commit_sha of a run fetches PR for that particular commit which is not related to the workflow run.
+            # however the pulls_url that I get in the run field has to do something with the run but does that mean the run is trigered by that pr? is it the same thing?
+            #The solution is to check it with an exampke small repo workflow run that event == pull_request? so I get my answer! :)
+
+            # Note: in the run field I can only access the pulls url in the form of pulls/number
+            # this "run.get("pull_requests", [])" is a different field in a run data field
+            #issues_url = run.get("issues_url", [])
+            #issue_url, issue_number, issue_title, issue_author, issue_date, issue_body, issue_labels = (fetch_issue_details(issues_url))
+            # "pulls_url": "https://api.github.com/repos/octo-org/octo-repo/pulls{/number}" a list of dict
+
+            # pull_request_url = run["pulls_url"]  # there are more than one key for a single run dictionary also, a generic template does't contain an actual number
+            # print("pull_request_url")
+
+            # pull_number = get_pull_number(pull_request_url)
+
+            # pr_title, pr_author, pr_created_at, base_repository, is_closed, merge_state_status, files_changed, no_of_files_changes, pr_labels, pr_body, pr_comments_url, pr_comments = fetch_pull_request_details(pr_number)
+
+            pull_requests = run.get("pull_requests", [])
+            if pull_requests:
+                for pr in pull_requests:
+                    pr_number = pr["number"]  # example url: 'url': 'https://api.github.com/repos/moqimoqidea/tomcat/pulls/254' 254 is pull number! also pulls_url pattern
+                    pr_title, pr_author, pr_created_at, pr_labels, pr_body, pr_comments_url = fetch_pull_request_details(pr_number)
+                    pull_request_comments = fetch_pull_request_comments(pr_comments_url) if pr_comments_url else []
+                    run_events_details = {
+                        "workflow_name": workflow_name,
+                        "run_id": run["id"],
+                        "run_number": run["run_number"],
+                        "run_status": run["status"],
+                        "run_conclusion": run["conclusion"],
+                        "event": run["event"],
+                        "url": run["url"],
+                        "commit_id": commit_sha,
+                        "commit_message": commit_message,
+                        "commit_author": commit_author,
+                        "commit_date": commit_date,
+                        "lines_added": lines_added,
+                        "lines_deleted": lines_deleted,
+                        "files_changed": files_changed,
+                        "pull_request_number": pr_number,
+                        "pr_comments_url": pr_comments_url,
+                        "pull_request_title": pr_title,
+                        "pull_request_author": pr_author,
+                        "pull_request_created_at": pr_created_at,
+                        "Pull_request_label": pr_labels,
+                        "pull_request_body": pr_body,
+                        "pull_request_comments": pull_request_comments
+                    }
+                    workflow_runs_list.append(run_events_details)
+                    run_details.append(run_events_details)
+            # Save single run
+            save_data_to_csv(run_details, run_filename)
+        # Save single workflow
+        save_data_to_csv(workflow_runs_list, file_name)

--- a/data_fetching/request.py
+++ b/data_fetching/request.py
@@ -64,5 +64,3 @@ def get_workflow_runs(url: str):
             next_page = response.links["next"]["url"]
 
     return all_runs
-
-


### PR DESCRIPTION
The logic to get all the pull requests for the workflow runs by getting the pulls_url key of the run. 

 How different is run["pulls_url"] vs PR that I get for each commit?

The PR obtained by commit_sha of a run retrieves the PR for that commit, which has nothing to do with runs! Since fetching PR using a run's commit_sha returns PR for that specific commit, which is irrelevant to the workflow run.
The pulls_url retrieved from the run field is relevant to the run, but whether it means the run is triggered by that PR is a separate debate.
